### PR TITLE
docs: fix misspelling from 'repace' to 'replace'

### DIFF
--- a/.github/steps/3-release-pr-opened.md
+++ b/.github/steps/3-release-pr-opened.md
@@ -18,7 +18,7 @@ In general, the pull request description can include:
 - A description of the changes proposed in the pull request.
 - [@mentions](https://docs.github.com/en/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.
 
-To expedite the creation of this pull request, I've added a pull request template to the repository. When you create a pull request, default text will automatically be displayed. This should help you identify and fill out all the necessary information. If you don't want to use the template content, just remove the text from the pull request and repace it with your pull request message.
+To expedite the creation of this pull request, I've added a pull request template to the repository. When you create a pull request, default text will automatically be displayed. This should help you identify and fill out all the necessary information. If you don't want to use the template content, just remove the text from the pull request and replace it with your pull request message.
 
 ### :keyboard: Activity: Open a release pull request
 


### PR DESCRIPTION
"Replace" is misspelled under Step 3.  This PR corrects this.

Fixes #58